### PR TITLE
[feat] 파일이름 형식 변경 및 CORS CONTENT_DISPOSITION 노출로 설정 변경

### DIFF
--- a/src/main/java/com/example/backend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/backend/auth/config/SecurityConfig.java
@@ -81,6 +81,7 @@ public class SecurityConfig {
     config.setAllowedOrigins(client);
     config.setAllowedMethods(Arrays.asList("POST", "GET", "PATCH", "DELETE", "PUT"));
     config.setAllowedHeaders(Arrays.asList(HttpHeaders.AUTHORIZATION, HttpHeaders.CONTENT_TYPE));
+    config.setExposedHeaders(Arrays.asList(HttpHeaders.CONTENT_DISPOSITION));
     config.setAllowCredentials(true);
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/example/backend/document/controller/DocumentController.java
+++ b/src/main/java/com/example/backend/document/controller/DocumentController.java
@@ -33,6 +33,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -314,7 +316,24 @@ public class DocumentController {
 
             // ✅ 5. PDF 생성
             byte[] pdfData = pdfService.generateSignedDocument(id, signatures);
-            String fileName = document.getFileName();
+
+            String fileName= "Unknown";
+            if(document.getType() == 1 ) {
+                // 1. 변수를 조건문 밖에서 미리 선언 (초기값 설정)
+                String subjectName = "Unknown";
+                Pattern pattern = Pattern.compile("^_*([^_]+)");
+                Matcher matcher = pattern.matcher(document.getRequestName());
+                // 2. 조건문 안에서 값을 할당
+                if (matcher.find()) {
+                    subjectName = matcher.group(1);
+                }
+                fileName = String.format("%s(%s)_%s.pdf",
+                        document.getMember().getName(),
+                        document.getMember().getUniqueId(),
+                        subjectName);
+            } else {
+                fileName = document.getFileName();
+            }
 
             String encodedFileName = URLEncoder.encode(fileName, "UTF-8")
                     .replaceAll("\\+", "%20");


### PR DESCRIPTION
DocumentController
파일이름 타입에 따라 구분하도록 변경
  -0이면 파일이름 사용
  -1이면 이름(학번)_과목명으로 설정
  
SecurityConfig
프론트에서 전달받는 파일명을 헤더에서 읽기 위해 CORS 설정에 파일이름을 담고있는 있는 CONTENT_DISPOSITION 헤더 속성 노출로 변경.